### PR TITLE
 feat: untrusted cert checks

### DIFF
--- a/token/claimBuilder.go
+++ b/token/claimBuilder.go
@@ -356,8 +356,23 @@ func (cb *clientCertificateClaimBuilder) AddClaims(_ context.Context, r *Request
 
 		case !expired && verifyErr == nil:
 			// we assume Trusted is the highest trust level
-			target[ClaimTrust] = cb.trust.Trusted
-			return
+			trust = cb.trust.Trusted
+		}
+
+		// Configured overrides.
+		for _, acc := range cb.untrustedCertChecks {
+			// Continue if we don't get a cert match, otherwise perform additional cert checks.
+			if !acc.SubjectCN.MatchString(pc.Subject.CommonName) {
+				continue
+			}
+
+			// Cert checks.
+			// If the cert's issuer common name matches the expected value, then the cert/device is untrusted – stop here.
+			if acc.IssuerCN.MatchString(pc.Issuer.CommonName) {
+				target[ClaimTrust] = cb.trust.Untrusted
+
+				return
+			}
 		}
 	}
 

--- a/token/claimBuilder.go
+++ b/token/claimBuilder.go
@@ -361,11 +361,6 @@ func (cb *clientCertificateClaimBuilder) AddClaims(_ context.Context, r *Request
 
 		// Configured overrides.
 		for _, acc := range cb.untrustedCertChecks {
-			// Continue if we don't get a cert match, otherwise perform additional cert checks.
-			if !acc.SubjectCN.MatchString(pc.Subject.CommonName) {
-				continue
-			}
-
 			// Cert checks.
 			// If the cert's issuer common name matches the expected value, then the cert/device is untrusted – stop here.
 			if acc.IssuerCN.MatchString(pc.Issuer.CommonName) {

--- a/token/claimBuilder.go
+++ b/token/claimBuilder.go
@@ -286,13 +286,18 @@ func newClientCertificateClaimBuiler(cc *ClientCertificates) (cb *clientCertific
 		cb.intermediates, err = xhttpserver.ReadCertPool(cc.IntermediatesFile)
 	}
 
+	for _, acc := range cc.UntrustedCertChecks {
+		cb.untrustedCertChecks = append(cb.untrustedCertChecks, acc.Build())
+	}
+
 	return
 }
 
 type clientCertificateClaimBuilder struct {
-	roots         *x509.CertPool
-	intermediates *x509.CertPool
-	trust         Trust
+	roots               *x509.CertPool
+	intermediates       *x509.CertPool
+	trust               Trust
+	untrustedCertChecks []CertChecks
 }
 
 func (cb *clientCertificateClaimBuilder) AddClaims(_ context.Context, r *Request, target map[string]interface{}) (err error) {

--- a/token/options.go
+++ b/token/options.go
@@ -220,27 +220,18 @@ type ClientCertificates struct {
 // UntrustedCertChecks describes additional cert checks to determine whether or not a cert should be considered untrusted.
 // If a cert fails all checks, then that it's untrusted.
 type UntrustedCertChecks struct {
-	// SubjectCNRegex is the regex of the certs' subject common name to check for.
-	SubjectCNRegex string
-
-	// Cert checks.
 	// IssuerCNRegex is the regex of the certs' issuer common name to check for.
 	IssuerCNRegex string
 }
 
 func (acc UntrustedCertChecks) Build() CertChecks {
 	return CertChecks{
-		SubjectCN: regexp.MustCompile(acc.SubjectCNRegex),
-		IssuerCN:  regexp.MustCompile(acc.IssuerCNRegex),
+		IssuerCN: regexp.MustCompile(acc.IssuerCNRegex),
 	}
 }
 
 // CertChecks is a collection of regexps to find certs of interest.
 type CertChecks struct {
-	// SubjectCNRegex is the regex of the certs' subject common name to check for.
-	SubjectCN *regexp.Regexp
-
-	// Checks.
 	// IssuerCNRegex is the regex of the certs' issuer common name to check for.
 	IssuerCN *regexp.Regexp
 }

--- a/token/options.go
+++ b/token/options.go
@@ -5,6 +5,7 @@ package token
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/xmidt-org/themis/v2/key"
@@ -211,6 +212,37 @@ type ClientCertificates struct {
 	// Trust defines the trust levels to set for various situations involving
 	// client certificates.
 	Trust Trust
+
+	// UntrustedCertChecks is a list of additional cert checks to perform against for untrusted certs.
+	UntrustedCertChecks []UntrustedCertChecks
+}
+
+// UntrustedCertChecks describes additional cert checks to determine whether or not a cert should be considered untrusted.
+// If a cert fails all checks, then that it's untrusted.
+type UntrustedCertChecks struct {
+	// SubjectCNRegex is the regex of the certs' subject common name to check for.
+	SubjectCNRegex string
+
+	// Cert checks.
+	// IssuerCNRegex is the regex of the certs' issuer common name to check for.
+	IssuerCNRegex string
+}
+
+func (acc UntrustedCertChecks) Build() CertChecks {
+	return CertChecks{
+		SubjectCN: regexp.MustCompile(acc.SubjectCNRegex),
+		IssuerCN:  regexp.MustCompile(acc.IssuerCNRegex),
+	}
+}
+
+// CertChecks is a collection of regexps to find certs of interest.
+type CertChecks struct {
+	// SubjectCNRegex is the regex of the certs' subject common name to check for.
+	SubjectCN *regexp.Regexp
+
+	// Checks.
+	// IssuerCNRegex is the regex of the certs' issuer common name to check for.
+	IssuerCN *regexp.Regexp
 }
 
 // Options holds the configurable information for a token Factory


### PR DESCRIPTION
Instead of returning once a trusted cert is found, go through all certs and perform additional checks.
If there's a positive match, then this device and certs are untrusted and we return.

The behavior does not change when moving the return statement after the trusted assignment, we simply cycle through all the certs and use the highest trusted cert if it hasn't fail the additional checks.